### PR TITLE
feat: logging response + content-encoding: gzip support

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -3,7 +3,10 @@
 (define name "raco-static-web")
 (define collection "raco-static-web")
 (define version "1.0.0")
-(define deps '("base" "web-server-lib" "mime-type-lib"))
+(define deps '("base"
+               "web-server-lib"
+               "mime-type-lib"
+               "version-case"))
 (define build-deps '())
 (define pkg-authors '(samdphillips@gmail.com))
 (define raco-commands

--- a/main.rkt
+++ b/main.rkt
@@ -23,12 +23,6 @@
          version-case
          (for-syntax racket/base))
 
-(define (my:path-mime-type p)
-  (cond
-    [(string-suffix? (~a p) ".gz")
-     #"application/gzip"]
-    [else (path-mime-type p)]))
-
 (version-case
  [(version< (version) "8.6")
   (begin
@@ -40,7 +34,7 @@
 
     (define (files:make url->path _gzip?)
       (static-files:make #:url->path url->path
-                         #:path->mime-type my:path-mime-type)))]
+                         #:path->mime-type path-mime-type)))]
  [else
   (begin
     (require (prefix-in log: web-server/dispatchers/dispatch-logresp))
@@ -55,7 +49,7 @@
         [else '()]))
     (define (files:make url->path gzip?)
       (static-files:make #:url->path url->path
-                         #:path->mime-type my:path-mime-type
+                         #:path->mime-type path-mime-type
                          #:path->headers (path->headers gzip?))))])
 
 


### PR DESCRIPTION
This PR makes three improvements

1. It adds logging response, a feature recently added in 8.6
2. It adds Content-Encoding: gzip support, a feature similarly recently added in 8.6.
3. It adds a workaround to support the .gz mime type (until https://github.com/Bogdanp/racket-net-mime-type/issues/1 is fixed, that is)

For Racket <8.6, the first and second features won't be available. We use version-case to accomplish this.

This PR should not be merged until
https://github.com/samth/version-case/pull/2 is first merged, however, since right now there are a lot of unnecessary dependencies in version-case. Once that's fixed, we can depend on it without worries.