### PR TITLE
Use `current-error-port` for logging output

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -203,7 +203,7 @@
       (serve #:port PORT
              #:dispatch
              (with-logging (#:format (log:log-format->format 'apache-default)
-                            #:log-path (current-output-port))
+                            #:log-path (current-error-port))
                (files:make url->path GZIP?)
                (favicon:make)
                (directory-lister:make #:url->path url->path)

--- a/main.rkt
+++ b/main.rkt
@@ -209,7 +209,7 @@
                (directory-lister:make #:url->path url->path)
                (lift:make not-found)))))
 
-  (displayln (~a "Now serving " BASE " from " server-url))
+  (displayln (~a "Now serving " BASE " from " server-url) (current-error-port))
   (when LAUNCH? (send-url server-url))
 
   (with-handlers ([exn:break? void]) (do-not-return))


### PR DESCRIPTION
Although there is not universal agreement, there seems to be a long-standing doctrine of using stderr for logging output. 

* GNU’s [Standard Streams](https://www.gnu.org/software/libc/manual/html_node/Standard-Streams.html), is often cited in discussions on this topic, which says stderr “is used for error messages and diagnostics issued by the program”. See, for example, [this reddit thread](https://www.reddit.com/r/golang/comments/jqvaft/why_does_the_log_package_always_output_to_stderr/).
* Go and Python’s loggers send output to stderr by default. 
* [How and when to use stdout and stderr?](https://julienharbulot.com/python-cli-streams.html) outlines the reasoning behind sending logging output to stderr.
* For comparison, Pollen’s `raco pollen start` web server uses stderr for logging output.

This isn’t merely an ideological thing; there is one minor  _practical_ difference, which is that stdout is usually block-buffered by default while stderr is unbuffered. I did [run into issues](https://racket.discourse.group/t/web-server-subprocess-logging-to-stdout-sometimes-not-available-until-after-subprocess-terminates/1673) running `raco static-web` as a subprocess inside a GUI program due to this difference. On the other hand, this is something I can work around any number of ways, and others are very unlikely to be affected by stdout’s buffering behavior. 

There _would_ be one more significant practical difference, if `raco-static-web` had any non-logging “normal output” that would be likely to be piped to other programs, and which could be said to be polluted by the logging info. That doesn’t apply here, though it might in the future.

Anyway, this is just a suggestion, not something I have a strong opinion about, despite the lengthy explanation I am giving here.